### PR TITLE
bump gha tox to v1.6.1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: true
       matrix:
         os: ['Ubuntu', 'MacOs', 'Windows']
-    uses: asottile/workflows/.github/workflows/tox.yml@v1.2.0
+    uses: asottile/workflows/.github/workflows/tox.yml@v1.6.1
     with:
       env: '["py38", "py39", "py310", "py311"]'
       os: ${{ matrix.os }}-latest


### PR DESCRIPTION
fix the failing CI because of macos-14
